### PR TITLE
Add a few wrappers to duck entries and logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(src/include)
 
 set(EXTENSION_SOURCES 
   src/motherduck_catalog.cpp
+  src/motherduck_catalog_entry.cpp
   src/motherduck_extension.cpp
   src/motherduck_schema.cpp
   src/motherduck_storage.cpp

--- a/src/include/motherduck_catalog.hpp
+++ b/src/include/motherduck_catalog.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/common/string.hpp"
@@ -64,14 +66,10 @@ public:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 
 private:
-	struct SchemaEntryWrapper {
-		unique_ptr<CreateSchemaInfo> create_schema_info;
-		unique_ptr<SchemaCatalogEntry> motherduck_schema_catalog_entry;
-	};
+	std::mutex mu;
+	unordered_map<string, unique_ptr<SchemaCatalogEntry>> schema_catalog_entries;
 
-	unordered_map<string, SchemaEntryWrapper> schema_catalog_entries;
 	unique_ptr<DuckCatalog> duckdb_catalog;
-
 	DatabaseInstance &db_instance;
 };
 

--- a/src/include/motherduck_catalog_entry.hpp
+++ b/src/include/motherduck_catalog_entry.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "duckdb/catalog/catalog_entry.hpp"
+
+namespace duckdb {
+
+// Forward declaration.
+class DatabaseInstance;
+
+class MotherduckCatalogEntry : public CatalogEntry {
+public:
+	MotherduckCatalogEntry(DatabaseInstance &db_instance_p, CatalogEntry *catalog_entry_p);
+	~MotherduckCatalogEntry() override = default;
+
+	unique_ptr<CatalogEntry> AlterEntry(ClientContext &context, AlterInfo &info) override;
+	unique_ptr<CatalogEntry> AlterEntry(CatalogTransaction transaction, AlterInfo &info) override;
+	void UndoAlter(ClientContext &context, AlterInfo &info) override;
+	void Rollback(CatalogEntry &prev_entry) override;
+	void OnDrop() override;
+	unique_ptr<CatalogEntry> Copy(ClientContext &context) const;
+	unique_ptr<CreateInfo> GetInfo() const;
+	void SetAsRoot() override;
+	string ToSQL() const;
+
+	Catalog &ParentCatalog() override;
+	const Catalog &ParentCatalog() const;
+	SchemaCatalogEntry &ParentSchema() override;
+	const SchemaCatalogEntry &ParentSchema() const;
+
+	void Verify(Catalog &catalog) override;
+
+private:
+	DatabaseInstance &db_instance;
+	CatalogEntry *catalog_entry;
+};
+
+} // namespace duckdb

--- a/src/include/motherduck_schema.hpp
+++ b/src/include/motherduck_schema.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <mutex>
+
 #include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
 
@@ -11,9 +16,9 @@ class DatabaseInstance;
 
 class MotherduckSchemaEntry : public SchemaCatalogEntry {
 public:
-	MotherduckSchemaEntry(Catalog &catalog, CreateSchemaInfo &info);
+	MotherduckSchemaEntry(DatabaseInstance &db_instance_p, SchemaCatalogEntry *schema_catalog_entry_p);
 
-	~MotherduckSchemaEntry();
+	~MotherduckSchemaEntry() override = default;
 
 	void Scan(ClientContext &context, CatalogType type, const std::function<void(CatalogEntry &)> &callback) override;
 
@@ -59,8 +64,12 @@ public:
 	void Verify(Catalog &catalog) override;
 
 private:
-	unique_ptr<DuckSchemaEntry> duckdb_schema_entry;
-	// DatabaseInstance& db_instance;
+	DatabaseInstance &db_instance;
+	SchemaCatalogEntry *schema_catalog_entry;
+
+	std::mutex mu;
+	// TODO(hjiang): Use a better key.
+	unordered_map<string, unique_ptr<CatalogEntry>> catalog_entries;
 };
 
 } // namespace duckdb

--- a/src/motherduck_catalog_entry.cpp
+++ b/src/motherduck_catalog_entry.cpp
@@ -1,0 +1,84 @@
+#include "motherduck_catalog_entry.hpp"
+
+#include "duckdb/catalog/catalog_transaction.hpp"
+#include "duckdb/logging/logger.hpp"
+#include "duckdb/parser/parsed_data/create_info.hpp"
+
+namespace duckdb {
+
+MotherduckCatalogEntry::MotherduckCatalogEntry(DatabaseInstance &db_instance_p, CatalogEntry *catalog_entry_p)
+    : CatalogEntry(catalog_entry_p->type, catalog_entry_p->name, catalog_entry_p->oid), db_instance(db_instance_p),
+      catalog_entry(catalog_entry_p) {
+}
+
+unique_ptr<CatalogEntry> MotherduckCatalogEntry::AlterEntry(ClientContext &context, AlterInfo &info) {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::AlterEntry");
+	return catalog_entry->AlterEntry(context, info);
+}
+
+unique_ptr<CatalogEntry> MotherduckCatalogEntry::AlterEntry(CatalogTransaction transaction, AlterInfo &info) {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::AlterEntry (CatalogTransaction)");
+	return catalog_entry->AlterEntry(std::move(transaction), info);
+}
+
+void MotherduckCatalogEntry::UndoAlter(ClientContext &context, AlterInfo &info) {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::UndoAlter");
+	catalog_entry->UndoAlter(context, info);
+}
+
+void MotherduckCatalogEntry::Rollback(CatalogEntry &prev_entry) {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::Rollback");
+	catalog_entry->Rollback(prev_entry);
+}
+
+void MotherduckCatalogEntry::OnDrop() {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::OnDrop");
+	catalog_entry->OnDrop();
+}
+
+unique_ptr<CatalogEntry> MotherduckCatalogEntry::Copy(ClientContext &context) const {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::Copy");
+	return catalog_entry->Copy(context);
+}
+
+unique_ptr<CreateInfo> MotherduckCatalogEntry::GetInfo() const {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::GetInfo");
+	return catalog_entry->GetInfo();
+}
+
+void MotherduckCatalogEntry::SetAsRoot() {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::SetAsRoot");
+	catalog_entry->SetAsRoot();
+}
+
+string MotherduckCatalogEntry::ToSQL() const {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::ToSQL");
+	return catalog_entry->ToSQL();
+}
+
+Catalog &MotherduckCatalogEntry::ParentCatalog() {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::ParentCatalog");
+	return catalog_entry->ParentCatalog();
+}
+
+const Catalog &MotherduckCatalogEntry::ParentCatalog() const {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::ParentCatalog (const)");
+	return catalog_entry->ParentCatalog();
+}
+
+SchemaCatalogEntry &MotherduckCatalogEntry::ParentSchema() {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::ParentSchema");
+	return catalog_entry->ParentSchema();
+}
+
+const SchemaCatalogEntry &MotherduckCatalogEntry::ParentSchema() const {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::ParentSchema (const)");
+	return catalog_entry->ParentSchema();
+}
+
+void MotherduckCatalogEntry::Verify(Catalog &catalog) {
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckCatalogEntry::Verify");
+	catalog_entry->Verify(catalog);
+}
+
+} // namespace duckdb

--- a/src/motherduck_schema.cpp
+++ b/src/motherduck_schema.cpp
@@ -1,105 +1,133 @@
 #include "motherduck_schema.hpp"
 
 #include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "motherduck_catalog.hpp"
+#include "motherduck_catalog_entry.hpp"
 #include "motherduck_table.hpp"
 
 namespace duckdb {
 
-MotherduckSchemaEntry::MotherduckSchemaEntry(Catalog &catalog, CreateSchemaInfo &info)
-    : SchemaCatalogEntry(catalog, info), duckdb_schema_entry(make_uniq<DuckSchemaEntry>(catalog, info)) {
+MotherduckSchemaEntry::MotherduckSchemaEntry(DatabaseInstance &db_instance_p,
+                                             SchemaCatalogEntry *schema_catalog_entry_p)
+    : SchemaCatalogEntry(schema_catalog_entry_p->catalog, schema_catalog_entry_p->GetInfo()->Cast<CreateSchemaInfo>()),
+      db_instance(db_instance_p), schema_catalog_entry(schema_catalog_entry_p) {
 }
-
-MotherduckSchemaEntry::~MotherduckSchemaEntry() = default;
 
 void MotherduckSchemaEntry::Scan(ClientContext &context, CatalogType type,
                                  const std::function<void(CatalogEntry &)> &callback) {
-	duckdb_schema_entry->Scan(context, type, callback);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::Scan");
+	schema_catalog_entry->Scan(context, type, callback);
 }
 
 void MotherduckSchemaEntry::Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) {
-	duckdb_schema_entry->Scan(type, callback);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::Scan");
+	schema_catalog_entry->Scan(type, callback);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,
                                                               TableCatalogEntry &table) {
-	return duckdb_schema_entry->CreateIndex(std::move(transaction), info, table);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateIndex");
+	return schema_catalog_entry->CreateIndex(std::move(transaction), info, table);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateFunction(CatalogTransaction transaction,
                                                                  CreateFunctionInfo &info) {
-	return duckdb_schema_entry->CreateFunction(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateFunction");
+	return schema_catalog_entry->CreateFunction(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateTable(CatalogTransaction transaction,
                                                               BoundCreateTableInfo &info) {
-	return duckdb_schema_entry->CreateTable(std::move(transaction), info);
+	auto create_table_str = info.base->ToString();
+	DUCKDB_LOG_DEBUG(db_instance, StringUtil::Format("MotherduckSchemaEntry::CreateTable %s", create_table_str));
+
+	auto duck_catalog_entry = schema_catalog_entry->CreateTable(std::move(transaction), info);
+	return duck_catalog_entry;
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
-	return duckdb_schema_entry->CreateView(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateView");
+	return schema_catalog_entry->CreateView(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateSequence(CatalogTransaction transaction,
                                                                  CreateSequenceInfo &info) {
-	return duckdb_schema_entry->CreateSequence(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateSequence");
+	return schema_catalog_entry->CreateSequence(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateTableFunction(CatalogTransaction transaction,
                                                                       CreateTableFunctionInfo &info) {
-	return duckdb_schema_entry->CreateTableFunction(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateTableFunction");
+	return schema_catalog_entry->CreateTableFunction(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateCopyFunction(CatalogTransaction transaction,
                                                                      CreateCopyFunctionInfo &info) {
-	return duckdb_schema_entry->CreateCopyFunction(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateCopyFunction");
+	return schema_catalog_entry->CreateCopyFunction(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreatePragmaFunction(CatalogTransaction transaction,
                                                                        CreatePragmaFunctionInfo &info) {
-	return duckdb_schema_entry->CreatePragmaFunction(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreatePragmaFunction");
+	return schema_catalog_entry->CreatePragmaFunction(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateCollation(CatalogTransaction transaction,
                                                                   CreateCollationInfo &info) {
-	return duckdb_schema_entry->CreateCollation(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateCollation");
+	return schema_catalog_entry->CreateCollation(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::CreateType(CatalogTransaction transaction, CreateTypeInfo &info) {
-	return duckdb_schema_entry->CreateType(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::CreateType");
+	return schema_catalog_entry->CreateType(std::move(transaction), info);
 }
 
 optional_ptr<CatalogEntry> MotherduckSchemaEntry::LookupEntry(CatalogTransaction transaction,
                                                               const EntryLookupInfo &lookup_info) {
-	return duckdb_schema_entry->LookupEntry(std::move(transaction), lookup_info);
+	auto lookup_entry = lookup_info.GetEntryName();
+	DUCKDB_LOG_DEBUG(db_instance, StringUtil::Format("MotherduckSchemaEntry::LookupEntry %s", lookup_entry));
+
+	// TODO(hjiang): Cache motherduck catalog entry, but it segfaults if we wrap it.
+	auto duck_catalog_entry = schema_catalog_entry->LookupEntry(std::move(transaction), lookup_info);
+	return duck_catalog_entry;
 }
 
 void MotherduckSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
-	duckdb_schema_entry->DropEntry(context, info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::DropEntry");
+	schema_catalog_entry->DropEntry(context, info);
 }
 
 void MotherduckSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
-	duckdb_schema_entry->Alter(std::move(transaction), info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::Alter");
+	schema_catalog_entry->Alter(std::move(transaction), info);
 }
 
 CatalogSet::EntryLookup MotherduckSchemaEntry::LookupEntryDetailed(CatalogTransaction transaction,
                                                                    const EntryLookupInfo &lookup_info) {
-	return duckdb_schema_entry->LookupEntryDetailed(std::move(transaction), lookup_info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::LookupEntryDetailed");
+	return schema_catalog_entry->LookupEntryDetailed(std::move(transaction), lookup_info);
 }
 
 SimilarCatalogEntry MotherduckSchemaEntry::GetSimilarEntry(CatalogTransaction transaction,
                                                            const EntryLookupInfo &lookup_info) {
-	return duckdb_schema_entry->GetSimilarEntry(std::move(transaction), lookup_info);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::GetSimilarEntry");
+	return schema_catalog_entry->GetSimilarEntry(std::move(transaction), lookup_info);
 }
 
 unique_ptr<CatalogEntry> MotherduckSchemaEntry::Copy(ClientContext &context) const {
-	return duckdb_schema_entry->Copy(context);
+	DUCKDB_LOG_DEBUG(db_instance, "MotherduckSchemaEntry::Copy");
+	return schema_catalog_entry->Copy(context);
 }
 
 void MotherduckSchemaEntry::Verify(Catalog &catalog) {
-	duckdb_schema_entry->Verify(catalog);
+	schema_catalog_entry->Verify(catalog);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
As titled, use self-implemented wrappers around duckdb entries, so we could add logging and see what's happening.
```sql
D CALL enable_logging(storage = 'stdout', level = 'debug');
┌─────────┐
│ Success │
│ boolean │
├─────────┤
│ 0 rows  │
└─────────┘
D ATTACH DATABASE 'md' (TYPE motherduck);
23      CONNECTION      2       6       6               2025-10-24 07:47:31.486397      QueryLog        INFO    ATTACH DATABASE 'md' (TYPE motherduck);
0       DATABASE                                        2025-10-24 07:47:31.486825      ""      DEBUG   MotherduckAttach
0       DATABASE                                        2025-10-24 07:47:31.486862      ""      DEBUG   MotherduckCreateTransactionManager
D CREATE TABLE md.my_table (id INTEGER, name TEXT, age INTEGER);
27      CONNECTION      2       7       7               2025-10-24 07:47:39.311191      QueryLog        INFO    "CREATE TABLE md.my_table (id INTEGER, name TEXT, age INTEGER);"
0       DATABASE                                        2025-10-24 07:47:39.312196      ""      DEBUG   MotherduckCatalog::LookupSchema main
0       DATABASE                                        2025-10-24 07:47:39.313389      ""      DEBUG   "MotherduckSchemaEntry::CreateTable CREATE TABLE md.main.my_table(id INTEGER, ""name"" VARCHAR, age INTEGER);"
D INSERT INTO md.my_table VALUES (1, 'Alice', 30), (2, 'Bob', 25), (3, 'Charlie', 40);
31      CONNECTION      2       8       8               2025-10-24 07:47:41.557776      QueryLog        INFO    "INSERT INTO md.my_table VALUES (1, 'Alice', 30), (2, 'Bob', 25), (3, 'Charlie', 40);"
0       DATABASE                                        2025-10-24 07:47:41.557922      ""      DEBUG   MotherduckCatalog::LookupSchema main
0       DATABASE                                        2025-10-24 07:47:41.557946      ""      DEBUG   MotherduckSchemaEntry::LookupEntry my_table
D SELECT * FROM md.my_table;
36      CONNECTION      2       9       9               2025-10-24 07:47:43.683026      QueryLog        INFO    SELECT * FROM md.my_table;
0       DATABASE                                        2025-10-24 07:47:43.683351      ""      DEBUG   MotherduckCatalog::LookupSchema main
0       DATABASE                                        2025-10-24 07:47:43.683428      ""      DEBUG   MotherduckSchemaEntry::LookupEntry my_table
┌───────┬─────────┬───────┐
│  id   │  name   │  age  │
│ int32 │ varchar │ int32 │
├───────┼─────────┼───────┤
│     1 │ Alice   │    30 │
│     2 │ Bob     │    25 │
│     3 │ Charlie │    40 │
└───────┴─────────┴───────┘
```