### PR TITLE
Add query timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ project(${TARGET_NAME})
 include_directories(src/include)
 
 set(EXTENSION_SOURCES
+  src/base_query_recorder.cpp
   src/distributed_delete.cpp
   src/distributed_insert.cpp
   src/distributed_server.cpp
@@ -30,6 +31,7 @@ set(EXTENSION_SOURCES
   src/motherduck_table_catalog_entry.cpp
   src/motherduck_transaction.cpp
   src/motherduck_transaction_manager.cpp
+  src/query_recorder.cpp
 )
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/src/base_query_recorder.cpp
+++ b/src/base_query_recorder.cpp
@@ -1,0 +1,24 @@
+#include "base_query_recorder.hpp"
+
+#include "time_utils.hpp"
+
+namespace duckdb {
+
+QueryRecorderHandle::QueryRecorderHandle(BaseQueryRecorder &query_recorder_p, string query_p)
+    : query_recorder(query_recorder_p), query(std::move(query_p)), start_timestamp(GetSteadyNowMilliSecSinceEpoch()) {
+}
+
+QueryRecorderHandle::~QueryRecorderHandle() {
+	const auto now = GetSteadyNowMilliSecSinceEpoch();
+	const auto latency_millisec = now - start_timestamp;
+	query_recorder.RecordFinish(std::move(query), latency_millisec);
+}
+
+QueryRecorderHandle NoopQueryRecorder::RecordQueryStart(string query) {
+	return QueryRecorderHandle {*this, std::move(query)};
+}
+
+void NoopQueryRecorder::RecordFinish(string query, uint64_t duration_millisec) {
+}
+
+} // namespace duckdb

--- a/src/include/base_query_recorder.hpp
+++ b/src/include/base_query_recorder.hpp
@@ -1,0 +1,52 @@
+// Class which records the runtime information of queries.
+
+#pragma once
+
+#include <cstdint>
+
+#include "duckdb/common/string.hpp"
+
+namespace duckdb {
+
+// Forward declaration.
+class BaseQueryRecorder;
+
+// A RAII handle for query recorder.
+class QueryRecorderHandle {
+public:
+	QueryRecorderHandle(BaseQueryRecorder &query_recorder_p, string query_p);
+	~QueryRecorderHandle();
+
+private:
+	BaseQueryRecorder &query_recorder;
+	string query;
+	int64_t start_timestamp = 0;
+};
+
+class BaseQueryRecorder {
+public:
+	BaseQueryRecorder() = default;
+	virtual ~BaseQueryRecorder() = default;
+
+	// Record the start of the query.
+	virtual QueryRecorderHandle RecordQueryStart(string query) = 0;
+
+private:
+	friend QueryRecorderHandle;
+
+	// Mark the completion of the query.
+	virtual void RecordFinish(string query, uint64_t duration_millisec) = 0;
+};
+
+class NoopQueryRecorder : public BaseQueryRecorder {
+public:
+	NoopQueryRecorder() = default;
+	~NoopQueryRecorder() override = default;
+
+	QueryRecorderHandle RecordQueryStart(string query) override;
+
+private:
+	void RecordFinish(string query, uint64_t duration_millisec) override;
+};
+
+} // namespace duckdb

--- a/src/include/query_recorder.hpp
+++ b/src/include/query_recorder.hpp
@@ -1,0 +1,25 @@
+#include "base_query_recorder.hpp"
+
+#include <cstdint>
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+class QueryRecorder : public BaseQueryRecorder {
+public:
+	QueryRecorder() = default;
+	~QueryRecorder() override = default;
+
+	QueryRecorderHandle RecordQueryStart(string query) override;
+
+private:
+	void RecordFinish(string query, uint64_t duration_millisec) override;
+
+	// Maps from query to their duration in milliseconds.
+	unordered_map<string, vector<int64_t>> query_timing;
+};
+
+} // namespace duckdb

--- a/src/include/time_utils.hpp
+++ b/src/include/time_utils.hpp
@@ -1,0 +1,43 @@
+// Time related utils.
+
+#pragma once
+
+#include "duckdb/common/types/timestamp.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+
+namespace duckdb {
+
+inline constexpr uint64_t kMicrosToNanos = 1000ULL;
+inline constexpr uint64_t kSecondsToMicros = 1000ULL * 1000ULL;
+inline constexpr uint64_t kSecondsToNanos = 1000ULL * 1000ULL * 1000ULL;
+inline constexpr uint64_t kMilliToNanos = 1000ULL * 1000ULL;
+
+// Get current timestamp in steady clock since epoch in nanoseconds.
+inline int64_t GetSteadyNowNanoSecSinceEpoch() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+	    .count();
+}
+
+// Get current timestamp in steady clock since epoch in milliseconds.
+inline int64_t GetSteadyNowMilliSecSinceEpoch() {
+	return GetSteadyNowNanoSecSinceEpoch() / kMilliToNanos;
+}
+
+// Get current timestamp in steady clock since epoch in nanoseconds.
+inline int64_t GetSystemNowNanoSecSinceEpoch() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
+	    .count();
+}
+
+// Get current timestamp in steady clock since epoch in milliseconds.
+inline int64_t GetSystemNowMilliSecSinceEpoch() {
+	return GetSystemNowNanoSecSinceEpoch() / kMilliToNanos;
+}
+
+// Convert from duckdb [`timestamp_t`] to [`time_t`].
+time_t DuckdbTimestampToTimeT(timestamp_t timestamp);
+
+} // namespace duckdb

--- a/src/query_recorder.cpp
+++ b/src/query_recorder.cpp
@@ -1,0 +1,13 @@
+#include "query_recorder.hpp"
+
+namespace duckdb {
+
+QueryRecorderHandle QueryRecorder::RecordQueryStart(string query) {
+	return QueryRecorderHandle {*this, std::move(query)};
+}
+
+void QueryRecorder::RecordFinish(string query, uint64_t duration_millisec) {
+	query_timing[std::move(query)].emplace_back(duration_millisec);
+}
+
+} // namespace duckdb

--- a/src/time_utils.cpp
+++ b/src/time_utils.cpp
@@ -1,0 +1,20 @@
+#include "duckdb/common/types/timestamp.hpp"
+#include "time_utils.hpp"
+
+namespace duckdb {
+
+time_t DuckdbTimestampToTimeT(timestamp_t timestamp) {
+	auto components = Timestamp::GetComponents(timestamp);
+	struct tm tm {};
+	tm.tm_year = components.year - 1900;
+	tm.tm_mon = components.month - 1;
+	tm.tm_mday = components.day;
+	tm.tm_hour = components.hour;
+	tm.tm_min = components.minute;
+	tm.tm_sec = components.second;
+	tm.tm_isdst = 0;
+	time_t result = mktime(&tm);
+	return result;
+}
+
+} // namespace duckdb


### PR DESCRIPTION
This PR adds a query timer, which could be used to record and query all executed queries.
Some potential improvements:
- It doesn't support querying ongoing queries
- It doesn't provide persistence, which means history disappears after connection ends