### PR TITLE
[1/N] Record query latency for table creation and drop

### DIFF
--- a/src/include/motherduck_catalog.hpp
+++ b/src/include/motherduck_catalog.hpp
@@ -2,6 +2,7 @@
 
 #include <mutex>
 
+#include "base_query_recorder.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/common/string.hpp"
@@ -94,6 +95,9 @@ private:
 
 	unique_ptr<DuckCatalog> duckdb_catalog;
 	DatabaseInstance &db_instance;
+
+	// Query recorder.
+	unique_ptr<BaseQueryRecorder> query_recorder;
 
 	// Remote table configuration.
 	// TODO(hjiang): Currently remote tables lives in memory, should provide options to persist and load.

--- a/src/include/motherduck_schema_catalog_entry.hpp
+++ b/src/include/motherduck_schema_catalog_entry.hpp
@@ -2,6 +2,7 @@
 
 #include <mutex>
 
+#include "base_query_recorder.hpp"
 #include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/entry_lookup_info.hpp"
@@ -24,7 +25,7 @@ class DatabaseInstance;
 class MotherduckSchemaCatalogEntry : public DuckSchemaEntry {
 public:
 	MotherduckSchemaCatalogEntry(Catalog &motherduck_catalog_p, DatabaseInstance &db_instance_p,
-	                             SchemaCatalogEntry *table_catalog_entry_p,
+	                             BaseQueryRecorder &query_recorder_p, SchemaCatalogEntry *table_catalog_entry_p,
 	                             unique_ptr<CreateSchemaInfo> create_schema_info_p);
 	~MotherduckSchemaCatalogEntry() override = default;
 
@@ -74,6 +75,7 @@ private:
 	CatalogEntry *WrapAndCacheTableCatalogEntryWithLock(EntryLookupInfoKey key, CatalogEntry *catalog_entry);
 
 	DatabaseInstance &db_instance;
+	BaseQueryRecorder &query_recorder;
 	unique_ptr<CreateSchemaInfo> create_schema_info;
 	SchemaCatalogEntry *schema_catalog_entry;
 	// Direct reference to MotherduckCatalog.

--- a/src/motherduck_catalog.cpp
+++ b/src/motherduck_catalog.cpp
@@ -19,11 +19,13 @@
 #include "duckdb/storage/database_size.hpp"
 #include "motherduck_schema_catalog_entry.hpp"
 #include "motherduck_transaction.hpp"
+#include "query_recorder.hpp"
 
 namespace duckdb {
 
 MotherduckCatalog::MotherduckCatalog(AttachedDatabase &db)
-    : DuckCatalog(db), duckdb_catalog(make_uniq<DuckCatalog>(db)), db_instance(db.GetDatabase()) {
+    : DuckCatalog(db), duckdb_catalog(make_uniq<DuckCatalog>(db)), db_instance(db.GetDatabase()),
+      query_recorder(make_uniq<QueryRecorder>()) {
 }
 
 MotherduckCatalog::~MotherduckCatalog() = default;
@@ -58,8 +60,8 @@ optional_ptr<SchemaCatalogEntry> MotherduckCatalog::LookupSchema(CatalogTransact
 
 		auto *schema_catalog_entry = dynamic_cast<SchemaCatalogEntry *>(catalog_entry.get());
 		D_ASSERT(schema_catalog_entry != nullptr);
-		auto motherduck_schema_entry = make_uniq<MotherduckSchemaCatalogEntry>(*this, db_instance, schema_catalog_entry,
-		                                                                       std::move(create_schema_info));
+		auto motherduck_schema_entry = make_uniq<MotherduckSchemaCatalogEntry>(
+		    *this, db_instance, *query_recorder, schema_catalog_entry, std::move(create_schema_info));
 		iter = schema_catalog_entries.emplace(std::move(entry_lookup_str), std::move(motherduck_schema_entry)).first;
 	}
 


### PR DESCRIPTION
This PR adds query latency recording for table creation and drop. In the next PR I will 
- Make a factory function and extension option to turn it on and off
- Create a function to query latency metrics