### PR TITLE
Delegate table entry call to parent class

### DIFF
--- a/src/include/client/motherduck_table_catalog_entry.hpp
+++ b/src/include/client/motherduck_table_catalog_entry.hpp
@@ -9,10 +9,6 @@ namespace duckdb {
 // Forward declaration.
 class BoundCreateTableInfo;
 class DatabaseInstance;
-class TableFunction;
-class TableStorageInfo;
-class MotherduckCatalog;
-class MotherduckSchemaCatalogEntry;
 
 class MotherduckTableCatalogEntry : public DuckTableEntry {
 public:
@@ -56,8 +52,8 @@ public:
 private:
 	DatabaseInstance &db_instance;
 	unique_ptr<BoundCreateTableInfo> bound_create_table_info;
-	DuckTableEntry *duck_table_entry;
-	Catalog &motherduck_catalog_ref; // Direct reference to MotherduckCatalog
+	// Direct reference to MotherduckCatalog.
+	Catalog &motherduck_catalog_ref;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This PR fixes an issue
- When a table gets updated, for example, adding or dropping a column, the old table entry gets invalidated inside of duckdb
- Current implementation for `MotherduckTableCatalogEntry` holds a raw pointer of `DuckTableCatalogEntry`, which is thus invalid after update
- In this PR, access is delegated to parent class