### PR TITLE
No distribution on small tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ duckdb_unittest_tempdir/
 testext
 test/python/__pycache__/
 .Rhistory
+vcpkg_installed/
 
 # Test database.
 md
 md.wal
+dh
+dh.wal

--- a/src/include/server/driver/task_partitioner.hpp
+++ b/src/include/server/driver/task_partitioner.hpp
@@ -23,6 +23,13 @@ public:
 	                                                     idx_t num_workers);
 
 private:
+	// Determine if distribution is needed based on table size.
+	// Returns false for small tables (< 1 row group) that should execute on a single node.
+	bool ShouldDistribute(idx_t estimated_cardinality) const;
+
+	// Create a single non-distributed task.
+	vector<DistributedPipelineTask> CreateSingleTask(const string &base_sql);
+
 	Connection &conn;
 	QueryPlanAnalyzer &analyzer;
 	PartitionSQLGenerator &sql_generator;

--- a/test/sql/row_group_partitioning.test
+++ b/test/sql/row_group_partitioning.test
@@ -1,5 +1,5 @@
 # name: test/sql/row_group_partitioning.test
-# description: Test ROW GROUP-BASED partitioning - COMPREHENSIVE test with multiple row groups
+# description: Test ROW GROUP-BASED partitioning with multiple row groups
 # group: [sql]
 
 # Partitioning method: rowid BETWEEN rg_start AND rg_end (aligned with row group boundaries)

--- a/test/sql/small_table_optimization.test
+++ b/test/sql/small_table_optimization.test
@@ -1,0 +1,125 @@
+# name: test/sql/small_table_optimization.test
+# description: Test that small tables (< 1 row group) execute on a single node without distribution
+# group: [sql]
+
+# Small tables with < 122,880 rows (DEFAULT_ROW_GROUP_SIZE) should not be distributed
+# to avoid unnecessary network overhead. They should execute on a single worker.
+
+require duckherder
+
+# Start distributed server with 4 workers
+statement ok
+SELECT duckherder_start_local_server(8815, 4);
+
+statement ok
+ATTACH DATABASE ':memory:' AS dh (TYPE duckherder, server_host 'localhost', server_port 8815);
+
+statement ok
+USE dh;
+
+# Test 1: Very small table (100 rows) - should NOT distribute
+statement ok
+PRAGMA duckherder_register_remote_table('tiny_table', 'tiny_table');
+
+statement ok
+DROP TABLE IF EXISTS tiny_table;
+
+statement ok
+CREATE TABLE tiny_table (
+    id INTEGER,
+    value INTEGER,
+    category VARCHAR
+);
+
+# Insert only 100 rows (much less than one row group)
+statement ok
+INSERT INTO tiny_table 
+SELECT 
+    i,
+    i * 10,
+    CASE (i % 3)
+        WHEN 0 THEN 'A'
+        WHEN 1 THEN 'B'
+        ELSE 'C'
+    END
+FROM range(100) t(i);
+
+# Verify all rows are accessible
+query I
+SELECT COUNT(*) FROM tiny_table;
+----
+100
+
+# Verify specific rows
+query III
+SELECT id, value, category FROM tiny_table WHERE id = 0;
+----
+0	0	A
+
+query III
+SELECT id, value, category FROM tiny_table WHERE id = 50;
+----
+50	500	C
+
+query III
+SELECT id, value, category FROM tiny_table WHERE id = 99;
+----
+99	990	A
+
+# Test 2: Small table (1,000 rows) - should NOT distribute
+statement ok
+PRAGMA duckherder_register_remote_table('small_table', 'small_table');
+
+statement ok
+DROP TABLE IF EXISTS small_table;
+
+statement ok
+CREATE TABLE small_table (
+    id INTEGER,
+    value INTEGER
+);
+
+statement ok
+INSERT INTO small_table 
+SELECT i, i * 100
+FROM range(1000) t(i);
+
+query I
+SELECT COUNT(*) FROM small_table;
+----
+1000
+
+# Test aggregation on small table
+query I
+SELECT SUM(value) FROM small_table;
+----
+49950000
+
+# Test 3: Medium-small table (10,000 rows) - should NOT distribute
+statement ok
+PRAGMA duckherder_register_remote_table('medium_small_table', 'medium_small_table');
+
+statement ok
+DROP TABLE IF EXISTS medium_small_table;
+
+statement ok
+CREATE TABLE medium_small_table (
+    id INTEGER,
+    value INTEGER
+);
+
+statement ok
+INSERT INTO medium_small_table 
+SELECT i, i * 10
+FROM range(10000) t(i);
+
+query I
+SELECT COUNT(*) FROM medium_small_table;
+----
+10000
+
+# Test filtering on medium-small table
+query II
+SELECT id, value FROM medium_small_table WHERE id = 5000;
+----
+5000	50000


### PR DESCRIPTION
In the current implementation, modulo-based partition and distribution is still used on small tables, which adds unnecessary overhead. In this PR, small queries are directly send to one single worker node.

TODO: we should add query execution status function to check distribution, table metadata and execution timing.