### PR TITLE
Add error logging for enum type conversion

### DIFF
--- a/src/arrow_utils.cpp
+++ b/src/arrow_utils.cpp
@@ -73,8 +73,9 @@ string GetDictionaryString(const std::shared_ptr<arrow::Array> &dictionary, int6
 		return str_array->GetString(idx);
 	}
 
-	throw NotImplementedException("Unsupported Arrow dictionary value type: %s (type_id: %d). Expected STRING or LARGE_STRING",
-	                              dictionary->type()->ToString(), static_cast<int>(dictionary->type_id()));
+	throw NotImplementedException(
+	    "Unsupported Arrow dictionary value type: %s (type_id: %d). Expected STRING or LARGE_STRING",
+	    dictionary->type()->ToString(), static_cast<int>(dictionary->type_id()));
 }
 
 // Util function to store an unsigned integer value in a DuckDB vector based on physical type.


### PR DESCRIPTION
This PR adds error logging so when type conversion fails, at least we know what're the unimplemented types in detail.